### PR TITLE
squid:S1319 - Declarations should use Java collection interfaces such…

### DIFF
--- a/src/main/java/com/waze/domain/WazeRouteDirection.java
+++ b/src/main/java/com/waze/domain/WazeRouteDirection.java
@@ -1,6 +1,6 @@
 package com.waze.domain;
 
-import java.util.ArrayList;
+import java.util.List;
 
 public class WazeRouteDirection {
 
@@ -8,12 +8,12 @@ public class WazeRouteDirection {
     private int routeDurationInMinutes;
     private double routeLengthKM;
     private boolean toll;
-    private ArrayList<WazeRoutePart> routeParts;
-    private ArrayList<String> routeStreets;
+    private List<WazeRoutePart> routeParts;
+    private List<String> routeStreets;
 
     public WazeRouteDirection(){}
 
-    public WazeRouteDirection(String routeName, int routeDurationInMinutes, double routeLengthKM, boolean toll, ArrayList<WazeRoutePart> routeParts, ArrayList<String> routeStreets) {
+    public WazeRouteDirection(String routeName, int routeDurationInMinutes, double routeLengthKM, boolean toll, List<WazeRoutePart> routeParts, List<String> routeStreets) {
         this.routeName = routeName;
         this.routeDurationInMinutes = routeDurationInMinutes;
         this.routeLengthKM = routeLengthKM;
@@ -26,11 +26,11 @@ public class WazeRouteDirection {
         return routeName;
     }
 
-    public ArrayList<WazeRoutePart> getRouteParts() {
+    public List<WazeRoutePart> getRouteParts() {
         return routeParts;
     }
 
-    public ArrayList<String> getRouteStreets() {
+    public List<String> getRouteStreets() {
         return routeStreets;
     }
 

--- a/src/main/java/com/waze/domain/WazeRouteResponse.java
+++ b/src/main/java/com/waze/domain/WazeRouteResponse.java
@@ -2,14 +2,14 @@ package com.waze.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by Nimrod_Lahav on 5/23/15.
  */
 public class WazeRouteResponse {
 
-    private ArrayList<WazeRoute> routes;
+    private List<WazeRoute> routes;
     private String startPoint;
     private String endPoint;
     private String startLatitude;
@@ -20,7 +20,7 @@ public class WazeRouteResponse {
     public WazeRouteResponse() {
     }
 
-    public WazeRouteResponse(ArrayList<WazeRoute> routes, String startPoint, String endPoint, String startLatitude, String startLongitude, String endLatitude, String endLongitude) {
+    public WazeRouteResponse(List<WazeRoute> routes, String startPoint, String endPoint, String startLatitude, String startLongitude, String endLatitude, String endLongitude) {
         this.routes = routes;
         this.startPoint = startPoint;
         this.endPoint = endPoint;
@@ -32,7 +32,7 @@ public class WazeRouteResponse {
 
 
     @JsonProperty
-    public ArrayList<WazeRoute> getRoutes() {
+    public List<WazeRoute> getRoutes() {
         return routes;
     }
 

--- a/src/main/java/com/waze/domain/WazeRouteWithDirectionsResponse.java
+++ b/src/main/java/com/waze/domain/WazeRouteWithDirectionsResponse.java
@@ -1,6 +1,6 @@
 package com.waze.domain;
 
-import java.util.ArrayList;
+import java.util.List;
 
 public class WazeRouteWithDirectionsResponse {
 
@@ -10,11 +10,11 @@ public class WazeRouteWithDirectionsResponse {
     private String startLongitude;
     private String endLatitude;
     private String endLongitude;
-    private ArrayList<WazeRouteDirection> routesWithDirections;
+    private List<WazeRouteDirection> routesWithDirections;
 
     public WazeRouteWithDirectionsResponse(){}
 
-    public WazeRouteWithDirectionsResponse(String startPoint, String endPoint, String startLatitude, String startLongitude, String endLatitude, String endLongitude, ArrayList<WazeRouteDirection> routesWithDirections) {
+    public WazeRouteWithDirectionsResponse(String startPoint, String endPoint, String startLatitude, String startLongitude, String endLatitude, String endLongitude, List<WazeRouteDirection> routesWithDirections) {
         this.startPoint = startPoint;
         this.endPoint = endPoint;
         this.startLatitude = startLatitude;
@@ -49,7 +49,7 @@ public class WazeRouteWithDirectionsResponse {
         return endLongitude;
     }
 
-    public ArrayList<WazeRouteDirection> getRoutesWithDirections() {
+    public List<WazeRouteDirection> getRoutesWithDirections() {
         return routesWithDirections;
     }
 

--- a/src/main/java/com/waze/domain/WazeTrafficNotificationsResponse.java
+++ b/src/main/java/com/waze/domain/WazeTrafficNotificationsResponse.java
@@ -1,25 +1,25 @@
 package com.waze.domain;
 
-import java.util.ArrayList;
+import java.util.List;
 
 public class WazeTrafficNotificationsResponse {
 
-    private ArrayList<WazeAlert> alerts;
-    private ArrayList<WazeJam> jams;
+    private List<WazeAlert> alerts;
+    private List<WazeJam> jams;
 
-    public ArrayList<WazeAlert> getAlerts() {
+    public List<WazeAlert> getAlerts() {
         return alerts;
     }
 
-    public void setAlerts(ArrayList<WazeAlert> alerts) {
+    public void setAlerts(List<WazeAlert> alerts) {
         this.alerts = alerts;
     }
 
-    public ArrayList<WazeJam> getJams() {
+    public List<WazeJam> getJams() {
         return jams;
     }
 
-    public void setJams(ArrayList<WazeJam> jams) {
+    public void setJams(List<WazeJam> jams) {
         this.jams = jams;
     }
 

--- a/src/main/java/com/waze/service/WazeNotificationService.java
+++ b/src/main/java/com/waze/service/WazeNotificationService.java
@@ -9,6 +9,7 @@ import com.waze.domain.WazeTrafficNotificationsResponse;
 import com.waze.utils.Utils;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by Nimrod_Lahav on 5/21/15.
@@ -31,8 +32,8 @@ public class WazeNotificationService {
         String[] serverList = {"rtserver", "row-rtserver", "il-rtserver"};
         String url = "";
         WazeTrafficNotificationsResponse wazeTrafficNotificationsResponse = new WazeTrafficNotificationsResponse();
-        ArrayList<WazeAlert> alerts = new ArrayList<>();
-        ArrayList<WazeJam> jams = new ArrayList<>();
+        List<WazeAlert> alerts = new ArrayList<>();
+        List<WazeJam> jams = new ArrayList<>();
 
 
         try{

--- a/src/main/java/com/waze/service/WazeRouteService.java
+++ b/src/main/java/com/waze/service/WazeRouteService.java
@@ -10,6 +10,7 @@ import com.waze.utils.Utils;
 
 import java.net.URLEncoder;
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by Nimrod_Lahav on 5/21/15.
@@ -34,7 +35,7 @@ public class WazeRouteService {
     public WazeStreetPickerResult getAddressOptionsFromFreeText(String addressText){
         JsonNode results = getAddress(addressText, multipleAddress);
 
-        ArrayList<String> addressList = new ArrayList<>();
+        List<String> addressList = new ArrayList<>();
         for (JsonNode address: results){
             addressList.add(Utils.getStringOrNull("name", address));
         }
@@ -45,11 +46,11 @@ public class WazeRouteService {
             return new WazeStreetPickerResult(addressList.subList(0, 10));
     }
 
-    private ArrayList<JsonNode> sendRouteRequestsWithFallback(String startLat, String startLon, String endLat, String endLon){
+    private List<JsonNode> sendRouteRequestsWithFallback(String startLat, String startLon, String endLat, String endLon){
 
         String[] serverList = {"RoutingManager", "row-RoutingManager", "il-RoutingManager"}; //TODO server list to conf file
 
-        ArrayList<JsonNode> routeResponse = new ArrayList<>();
+        List<JsonNode> routeResponse = new ArrayList<>();
 
         for (String server: serverList){
             String routeURL = createWazeRouteURL(server, startLat, startLon, endLat, endLon);
@@ -87,9 +88,9 @@ public class WazeRouteService {
 
     public WazeRouteWithDirectionsResponse getRouteWithParts(String startLat, String startLon, String endLat, String endLon,String start , String end) {
 
-        ArrayList<WazeRouteDirection> wazeRouteDirections = new ArrayList<>();
+        List<WazeRouteDirection> wazeRouteDirections = new ArrayList<>();
 
-        ArrayList<JsonNode> routeResponse = sendRouteRequestsWithFallback(startLat, startLon, endLat, endLon);
+        List<JsonNode> routeResponse = sendRouteRequestsWithFallback(startLat, startLon, endLat, endLon);
 
         if (routeResponse.isEmpty()){
             return null;
@@ -104,7 +105,7 @@ public class WazeRouteService {
             int routeLengthMeter = 0;
 
             String routeName = Utils.getX2StringOrNull(RESPONSE, "routeName", routeNode);
-            ArrayList<String> streetList = new ArrayList<>();
+            List<String> streetList = new ArrayList<>();
 
             JsonNode streets = routeNode.get(RESPONSE).get("streetNames");
 
@@ -112,7 +113,7 @@ public class WazeRouteService {
                 streetList.add(street.asText());
             }
 
-            ArrayList<WazeRoutePart> wazeRouteParts = new ArrayList<>();
+            List<WazeRoutePart> wazeRouteParts = new ArrayList<>();
             JsonNode routeParts = routeNode.get(RESPONSE).get("results");
             for (JsonNode part : routeParts) {
 
@@ -148,9 +149,9 @@ public class WazeRouteService {
 
     public WazeRouteResponse getRoutes(String startLat, String startLon, String endLat, String endLon,String start , String end) {
 
-        ArrayList<JsonNode> routeResponse = sendRouteRequestsWithFallback(startLat, startLon, endLat, endLon);
+        Iterable<JsonNode> routeResponse = sendRouteRequestsWithFallback(startLat, startLon, endLat, endLon);
 
-        ArrayList<WazeRoute> routes = new ArrayList<>();
+        List<WazeRoute> routes = new ArrayList<>();
         String startLatitude = "";
         String startLongitude = "";
         String endLatitude = "";
@@ -207,8 +208,8 @@ public class WazeRouteService {
 
 
 
-    public ArrayList<JsonNode> sendRouteRequest(String routeUrl){
-        ArrayList<JsonNode> routes = new ArrayList<>();
+    public List<JsonNode> sendRouteRequest(String routeUrl){
+        List<JsonNode> routes = new ArrayList<>();
         try{
             Response response = asyncHttpClient
                     .prepareGet(routeUrl)

--- a/src/test/java/com/waze/WazeRouteServiceTest.java
+++ b/src/test/java/com/waze/WazeRouteServiceTest.java
@@ -12,7 +12,7 @@ import com.waze.service.WazeRouteService;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by Nimrod_Lahav on 5/22/15.
@@ -60,7 +60,7 @@ public class WazeRouteServiceTest {
     @Test
     @Ignore
     public void testWazeRouteApi(){
-        ArrayList<JsonNode> routeResult = wazeRouteService.sendRouteRequest("https://www.waze.com/RoutingManager/routingRequest?from=x%3A-73.96537017822266+y%3A40.77473068237305&to=x%3A-73.99018859863281+y%3A40.751678466796875&at=0&returnJSON=true&returnGeometries=true&returnInstructions=true&timeout=60000&nPaths=3&options=AVOID_TRAILS%3At");
+        List<JsonNode> routeResult = wazeRouteService.sendRouteRequest("https://www.waze.com/RoutingManager/routingRequest?from=x%3A-73.96537017822266+y%3A40.77473068237305&to=x%3A-73.99018859863281+y%3A40.751678466796875&at=0&returnJSON=true&returnGeometries=true&returnInstructions=true&timeout=60000&nPaths=3&options=AVOID_TRAILS%3At");
         String routeName = routeResult.get(0).get("response").get("routeName").asText();
         assert(!routeName.equals(""));
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1319 - Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1319

Please let me know if you have any questions.

M-Ezzat